### PR TITLE
Add eth1 & eth2 cobra flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,5 +7,6 @@
 - Add JSON-RPC client to connect to any JSON-RPC server over HTTP
 - Add Eth1 client to connect to any Ethereum 1.0 node over HTTP
 - Add Eth2 client to connect to any Ethereum 2.0 beacon node over HTTP
+- Add a collection of Ethereum 1.0 & 2.0 flags compatible with [Cobra](https://github.com/spf13/cobra) library to build CLI applications
 
 ### 🛠 Bug fixes

--- a/README.md
+++ b/README.md
@@ -25,3 +25,5 @@ Go-Utils is a library containing a collection of Golang utilities
     | Use go context for timeout and cancellation                              | Yes       |
     | Use core [protolambda/zrnt](https://github.com/protolambda/zrnt) types   | Yes      |
     | Provides tracing for requests                                            | Not Yet   |
+
+- A collection of Ethereum 1.0 & 2.0 flags compatible with [Cobra](https://github.com/spf13/cobra) library to build CLI applications that need to interact with blockchain nodes

--- a/eth1/call_opts.go
+++ b/eth1/call_opts.go
@@ -1,0 +1,14 @@
+package eth1
+
+import (
+	"math/big"
+
+	gethcommon "github.com/ethereum/go-ethereum/common"
+)
+
+// CallOpts is a set of option to fine tune a contract call request
+type CallOpts struct {
+	Pending     bool               // Whether to operate on the pending state or the last known one
+	From        gethcommon.Address // Optional the sender address, otherwise the first account is used
+	BlockNumber *big.Int           // Optional the block number on which the call should be performed
+}

--- a/eth1/flag/address.go
+++ b/eth1/flag/address.go
@@ -1,0 +1,40 @@
+package flag
+
+import (
+	"fmt"
+
+	gethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/spf13/pflag"
+)
+
+// addressValue is a type implenting pflag.Value interface for gethcommon.Address type
+type addressValue struct {
+	addr *gethcommon.Address
+}
+
+func (v *addressValue) Set(s string) error {
+	if !gethcommon.IsHexAddress(s) {
+		return fmt.Errorf("invalid Ethereum address %q", s)
+	}
+
+	v.addr.SetBytes(gethcommon.HexToAddress(s).Bytes())
+
+	return nil
+}
+
+func (v *addressValue) Type() string   { return "address" }
+func (v *addressValue) String() string { return v.addr.String() }
+
+// AddressVar registers a gethcommon.Address custom flag with specified name, default value, and usage string.
+// The argument p points to a gethcommon.Address variable in which to store the value of the flag
+func AddressVar(f *pflag.FlagSet, p *gethcommon.Address, name string, value gethcommon.Address, usage string) {
+	p.SetBytes(value.Bytes())
+	f.Var(&addressValue{p}, name, usage)
+}
+
+// AddressVar registers a gethcommon.Address custom flag with specified name, and shorthand, default value, and usage string.
+// The argument p points to a gethcommon.Address variable in which to store the value of the flag
+func AddressVarP(f *pflag.FlagSet, p *gethcommon.Address, name, shorthand string, value gethcommon.Address, usage string) {
+	p.SetBytes(value.Bytes())
+	f.VarP(&addressValue{p}, name, shorthand, usage)
+}

--- a/eth1/flag/big.go
+++ b/eth1/flag/big.go
@@ -1,0 +1,38 @@
+package flag
+
+import (
+	"math/big"
+
+	"github.com/spf13/pflag"
+
+	"github.com/skillz-blockchain/go-utils/eth1"
+)
+
+type bigIntValue struct {
+	block **big.Int
+}
+
+func (b bigIntValue) String() string { return eth1.EncodeBig(*b.block) }
+func (b bigIntValue) Type() string   { return "bigInt" }
+func (b *bigIntValue) Set(s string) error {
+	bn, err := eth1.DecodeBig(s)
+	if err != nil {
+		return err
+	}
+	*b.block = bn
+	return nil
+}
+
+// BigIntVar register a *big.Int custom flag with specified name, default value, and usage string.
+// The argument p points to a *big.Int variable in which to store the value of the flag
+func BigIntVar(f *pflag.FlagSet, p **big.Int, name string, value *big.Int, usage string) {
+	*p = value
+	f.Var(&bigIntValue{p}, name, usage)
+}
+
+// BigIntVar registers a *big.Int custom flag with specified name and shorthand, default value, and usage string.
+// The argument p points to a *big.Int variable in which to store the value of the flag
+func BigIntVarP(f *pflag.FlagSet, p **big.Int, name, shorthand string, value *big.Int, usage string) {
+	*p = value
+	f.VarP(&bigIntValue{p}, name, shorthand, usage)
+}

--- a/eth1/flag/block_number.go
+++ b/eth1/flag/block_number.go
@@ -1,0 +1,38 @@
+package flag
+
+import (
+	"math/big"
+
+	"github.com/spf13/pflag"
+
+	"github.com/skillz-blockchain/go-utils/eth1"
+)
+
+type blockNumberValue struct {
+	block **big.Int
+}
+
+func (b blockNumberValue) String() string { return eth1.ToBlockNumArg(*b.block) }
+func (b blockNumberValue) Type() string   { return "blockNumber" }
+func (b *blockNumberValue) Set(s string) error {
+	bn, err := eth1.FromBlockNumArg(s)
+	if err != nil {
+		return err
+	}
+	*b.block = bn
+	return nil
+}
+
+// BlockNumberVar registers a *big.Int blocknumber custom flag with specified name, default value, and usage string.
+// The argument p points to a *big.Int variable in which to store the value of the flag
+func BlockNumberVar(f *pflag.FlagSet, p **big.Int, name string, value *big.Int, usage string) {
+	*p = value
+	f.Var(&blockNumberValue{p}, name, usage)
+}
+
+// BlockNumberVar registers a *big.Int blocknumber custom flag with specified name and shorthand, default value, and usage string.
+// The argument p points to a *big.Int variable in which to store the value of the flag
+func BlockNumberVarP(f *pflag.FlagSet, b **big.Int, name, shorthand string, value *big.Int, usage string) {
+	*b = value
+	f.VarP(&blockNumberValue{b}, name, shorthand, usage)
+}

--- a/eth1/flag/block_number_test.go
+++ b/eth1/flag/block_number_test.go
@@ -1,0 +1,35 @@
+package flag
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBlockNumber(t *testing.T) {
+	t.Run("default nil and flag unset", func(t *testing.T) {
+		b := big.NewInt(0)
+		flags := pflag.NewFlagSet("test", pflag.PanicOnError)
+		BlockNumberVar(flags, &b, "test-block", nil, "Test usage")
+		flags.Parse([]string{})
+		assert.Nil(t, b)
+	})
+
+	t.Run("default nil and flag set", func(t *testing.T) {
+		b := big.NewInt(0)
+		flags := pflag.NewFlagSet("test", pflag.PanicOnError)
+		BlockNumberVar(flags, &b, "test-block", nil, "Test usage")
+		flags.Parse([]string{"--test-block", "0x1"})
+		assert.Equal(t, big.NewInt(1), b)
+	})
+
+	t.Run("default not nil and flag set", func(t *testing.T) {
+		b := big.NewInt(0)
+		flags := pflag.NewFlagSet("test", pflag.PanicOnError)
+		BlockNumberVar(flags, &b, "test-block", nil, "Test usage")
+		flags.Parse([]string{"--test-block", "0x1"})
+		assert.Equal(t, big.NewInt(1), b)
+	})
+}

--- a/eth1/flag/call_opts.go
+++ b/eth1/flag/call_opts.go
@@ -1,0 +1,33 @@
+package flag
+
+import (
+	gethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/spf13/pflag"
+
+	"github.com/skillz-blockchain/go-utils/eth1"
+)
+
+// CallOptsVar registers a set of custom flags for eth1.CallOpts
+func CallOptsVar(f *pflag.FlagSet, callOpts *eth1.CallOpts) {
+	BlockNumberVarP(
+		f,
+		&callOpts.BlockNumber,
+		"block",
+		"b",
+		nil,
+		"Optional the block number on which the call should be performed",
+	)
+	f.BoolVar(
+		&callOpts.Pending,
+		"pending",
+		false,
+		"Optional whether to operate on the pending state or the last known one",
+	)
+	AddressVar(
+		f,
+		&callOpts.From,
+		"from",
+		gethcommon.Address{},
+		"Optional call's sender address in hex format with 0x prefix",
+	)
+}

--- a/eth1/flag/transact_opts.go
+++ b/eth1/flag/transact_opts.go
@@ -1,0 +1,227 @@
+package flag
+
+import (
+	"math/big"
+
+	gethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/spf13/pflag"
+
+	"github.com/skillz-blockchain/go-utils/eth1"
+)
+
+// TransactOptsVar registers a set of custom flags for eth1.TransactOpts
+func TransactOptsVar(f *pflag.FlagSet, txOpts *eth1.TransactOpts) {
+	AddressVar(
+		f,
+		&txOpts.From,
+		"from",
+		gethcommon.Address{},
+		`Optional account used to sign the transaction.
+Expects an 0x prefixed Ethereum address`,
+	)
+	BigIntVarP(
+		f,
+		&txOpts.Nonce,
+		"nonce",
+		"n",
+		nil,
+		`Optional nonce to use for the transaction, if not set then use pending nonce.
+Expects either a decimal or an hex encoded value with 0x prefix`,
+	)
+	BigIntVarP(
+		f,
+		&txOpts.Value,
+		"value",
+		"v",
+		big.NewInt(0),
+		`Optional funds to transfer along the transaction in Wei, if not set then no funds are transfered
+Expects either a decimal or an hex encoded value with 0x prefix`,
+	)
+	BigIntVarP(
+		f,
+		&txOpts.GasPrice,
+		"gas-price",
+		"p",
+		nil,
+		`Optional gas price to use for the transaction execution in Wei. If not set then uses gas price oracle
+Expects either a decimal or an hex encoded value with 0x prefix`,
+	)
+	BigIntVarP(
+		f,
+		&txOpts.GasFeeCap,
+		"gas-fee-cap",
+		"f",
+		nil,
+		`Optional gas fee cap to use for the EIP-1559 transaction execution in Wei. If not set then uses gas price oracle
+Expects either a decimal or an hex encoded value with 0x prefix`,
+	)
+	BigIntVarP(
+		f,
+		&txOpts.GasTipCap,
+		"gas-tip-cap",
+		"t",
+		nil,
+		`Optional gas priority tip fee cap to use for the EIP-1559 transaction execution in Wei. If not set then uses gas price oracle
+Expects either a decimal or an hex encoded value with 0x prefix`,
+	)
+	f.Uint64VarP(
+		&txOpts.GasLimit,
+		"gas-limit",
+		"l",
+		0,
+		`Optional gas limit to set for the transaction execution. If not set then estimate gas
+Expects either a decimal or an hex encoded value with 0x prefix`,
+	)
+
+	// We want NoSend to be true by default
+	f.BoolVar(
+		&txOpts.Send,
+		"send",
+		false,
+		"If not set then performs all transaction steps but does not send the transaction",
+	)
+}
+
+// // txOptsNonceValue is a type implenting pflag.Value interface
+// type txOptsNonceValue struct {
+// 	txOpts *eth1.TransactOpts
+// }
+
+// func (v *txOptsNonceValue) Set(s string) error {
+// 	if s != "" {
+// 		n, err := eth1.DecodeBig(s)
+// 		if err != nil {
+// 			return err
+// 		}
+// 		v.txOpts.Nonce = n
+// 	}
+
+// 	return nil
+// }
+
+// func (v *txOptsNonceValue) Type() string { return "string" }
+// func (v *txOptsNonceValue) String() string {
+// 	if v.txOpts.Nonce == nil {
+// 		return ""
+// 	}
+// 	return gethhexutil.EncodeBig(v.txOpts.Nonce)
+// }
+
+// // txOptsValueValue is a type implenting pflag.Value interface
+// type txOptsValueValue struct {
+// 	txOpts *eth1.TransactOpts
+// }
+
+// func (v *txOptsValueValue) Set(s string) error {
+// 	if s != "" {
+// 		val, err := eth1.DecodeBig(s)
+// 		if err != nil {
+// 			return err
+// 		}
+// 		v.txOpts.Value = val
+// 	}
+
+// 	return nil
+// }
+
+// func (v *txOptsValueValue) Type() string { return "string" }
+// func (v *txOptsValueValue) String() string {
+// 	if v.txOpts.Value == nil {
+// 		return ""
+// 	}
+// 	return gethhexutil.EncodeBig(v.txOpts.Value)
+// }
+
+// // txOptsGasPriceValue is a type implenting pflag.Value interface
+// type txOptsGasPriceValue struct {
+// 	txOpts *eth1.TransactOpts
+// }
+
+// func (v *txOptsGasPriceValue) Set(s string) error {
+// 	if s != "" {
+// 		p, err := eth1.DecodeBig(s)
+// 		if err != nil {
+// 			return err
+// 		}
+// 		v.txOpts.GasPrice = p
+// 	}
+
+// 	return nil
+// }
+
+// func (v *txOptsGasPriceValue) Type() string { return "string" }
+// func (v *txOptsGasPriceValue) String() string {
+// 	if v.txOpts.GasPrice == nil {
+// 		return ""
+// 	}
+// 	return gethhexutil.EncodeBig(v.txOpts.GasPrice)
+// }
+
+// type txOptsGasFeeCapValue struct {
+// 	txOpts *eth1.TransactOpts
+// }
+
+// func (v *txOptsGasFeeCapValue) Set(s string) error {
+// 	if s != "" {
+// 		p, err := eth1.DecodeBig(s)
+// 		if err != nil {
+// 			return err
+// 		}
+// 		v.txOpts.GasFeeCap = p
+// 	}
+
+// 	return nil
+// }
+
+// func (v *txOptsGasFeeCapValue) Type() string { return "string" }
+// func (v *txOptsGasFeeCapValue) String() string {
+// 	if v.txOpts.GasFeeCap == nil {
+// 		return ""
+// 	}
+// 	return gethhexutil.EncodeBig(v.txOpts.GasFeeCap)
+// }
+
+// type txOptsGasTipCapValue struct {
+// 	txOpts *eth1.TransactOpts
+// }
+
+// func (v *txOptsGasTipCapValue) Set(s string) error {
+// 	if s != "" {
+// 		p, err := eth1.DecodeBig(s)
+// 		if err != nil {
+// 			return err
+// 		}
+// 		v.txOpts.GasTipCap = p
+// 	}
+
+// 	return nil
+// }
+
+// func (v *txOptsGasTipCapValue) Type() string { return "string" }
+// func (v *txOptsGasTipCapValue) String() string {
+// 	if v.txOpts.GasTipCap == nil {
+// 		return ""
+// 	}
+// 	return gethhexutil.EncodeBig(v.txOpts.GasTipCap)
+// }
+
+// type txOptsGasLimitValue struct {
+// 	txOpts *eth1.TransactOpts
+// }
+
+// func (v *txOptsGasLimitValue) Set(s string) error {
+// 	if s != "" {
+// 		p, err := eth1.DecodeBig(s)
+// 		if err != nil {
+// 			return err
+// 		}
+// 		v.txOpts.GasLimit = p.Uint64()
+// 	}
+
+// 	return nil
+// }
+
+// func (v *txOptsGasLimitValue) Type() string { return "string" }
+// func (v *txOptsGasLimitValue) String() string {
+// 	return gethhexutil.EncodeBig(big.NewInt(int64(v.txOpts.GasLimit)))
+// }

--- a/eth1/transact_opts.go
+++ b/eth1/transact_opts.go
@@ -1,0 +1,21 @@
+package eth1
+
+import (
+	"math/big"
+
+	gethcommon "github.com/ethereum/go-ethereum/common"
+)
+
+// TransactOpts is a set of option to fine tune the creation of a valid Ethereum transaction.
+type TransactOpts struct {
+	From gethcommon.Address // Ethereum account to send the transaction from
+
+	Nonce     *big.Int // Nonce to use for the transaction execution (nil = use pending state)
+	Value     *big.Int // Funds to transfer along the transaction (nil = 0 = no funds)
+	GasPrice  *big.Int // Gas price to use for the transaction execution (nil = gas price oracle)
+	GasFeeCap *big.Int // Gas fee cap to use for the 1559 transaction execution (nil = gas price oracle)
+	GasTipCap *big.Int // Gas priority fee cap to use for the 1559 transaction execution (nil = gas price oracle)
+	GasLimit  uint64   // Gas limit to set for the transaction execution (0 = estimate)
+
+	Send bool // Do all transact steps and send the transaction
+}

--- a/eth2/flag/epoch.go
+++ b/eth2/flag/epoch.go
@@ -1,0 +1,31 @@
+package flag
+
+import (
+	beaconcommon "github.com/protolambda/zrnt/eth2/beacon/common"
+	"github.com/spf13/pflag"
+)
+
+// epochValue is a type implenting pflag.Value interface for beaconcommon.Epoch type
+type epochValue struct {
+	epoch *beaconcommon.Epoch
+}
+
+func (v *epochValue) Set(s string) error { return v.epoch.UnmarshalJSON([]byte(s)) }
+func (v *epochValue) Type() string       { return "epoch" }
+func (v *epochValue) String() string     { return v.epoch.String() }
+
+// EpochVar registers a beaconcommon.Epoch custom flag with specified name, default value, and usage string.
+// The argument p points to a beaconcommon.Epoch variable in which to store the value of the flag
+func EpochVar(f *pflag.FlagSet, p *beaconcommon.Epoch, name string, value beaconcommon.Epoch, usage string) {
+	v := &epochValue{p}
+	*v.epoch = value
+	f.Var(v, name, usage)
+}
+
+// EpochVar registers a beaconcommon.Epoch custom flag with specified name and shorthand, default value, and usage string.
+// The argument p points to a beaconcommon.Epoch variable in which to store the value of the flag
+func EpochVarP(f *pflag.FlagSet, p *beaconcommon.Epoch, name, shorthand string, value beaconcommon.Epoch, usage string) {
+	v := &epochValue{p}
+	*v.epoch = value
+	f.VarP(v, name, shorthand, usage)
+}

--- a/eth2/flag/gwei.go
+++ b/eth2/flag/gwei.go
@@ -1,0 +1,31 @@
+package flag
+
+import (
+	beaconcommon "github.com/protolambda/zrnt/eth2/beacon/common"
+	"github.com/spf13/pflag"
+)
+
+// GweiValue is a type implenting pflag.Value interface for beaconcommon.Gwei type
+type GweiValue struct {
+	Gwei *beaconcommon.Gwei
+}
+
+func (v *GweiValue) Set(s string) error { return v.Gwei.UnmarshalJSON([]byte(s)) }
+func (v *GweiValue) Type() string       { return "Gwei" }
+func (v *GweiValue) String() string     { return v.Gwei.String() }
+
+// GweiVar registers a beaconcommon.Gwei custom flag with specified name, default value, and usage string.
+// The argument p points to a beaconcommon.Gwei variable in which to store the value of the flag
+func GweiVar(f *pflag.FlagSet, p *beaconcommon.Gwei, name string, value beaconcommon.Gwei, usage string) {
+	v := &GweiValue{p}
+	*v.Gwei = value
+	f.Var(v, name, usage)
+}
+
+// GweiVar registers a beaconcommon.Gwei custom flag with specified name and shorthand, default value, and usage string.
+// The argument p points to a beaconcommon.Gwei variable in which to store the value of the flag
+func GweiVarP(f *pflag.FlagSet, p *beaconcommon.Gwei, name, shorthand string, value beaconcommon.Gwei, usage string) {
+	v := &GweiValue{p}
+	*v.Gwei = value
+	f.VarP(v, name, shorthand, usage)
+}

--- a/eth2/flag/slot.go
+++ b/eth2/flag/slot.go
@@ -1,0 +1,31 @@
+package flag
+
+import (
+	beaconcommon "github.com/protolambda/zrnt/eth2/beacon/common"
+	"github.com/spf13/pflag"
+)
+
+// slotValue is a type implenting pflag.Value interface for beaconcommon.Epoch type
+type slotValue struct {
+	slot *beaconcommon.Slot
+}
+
+func (v *slotValue) Set(s string) error { return v.slot.UnmarshalJSON([]byte(s)) }
+func (v *slotValue) Type() string       { return "slot" }
+func (v *slotValue) String() string     { return v.slot.String() }
+
+// SlotVar registers a beaconcommon.Slot custom flag with specified name, default value, and usage string.
+// The argument p points to a beaconcommon.Slot variable in which to store the value of the flag
+func SlotVar(f *pflag.FlagSet, p *beaconcommon.Slot, name string, value beaconcommon.Slot, usage string) {
+	v := &slotValue{p}
+	*v.slot = value
+	f.Var(v, name, usage)
+}
+
+// SlotVar registers a beaconcommon.Slot custom flag with specified name and shorthand, default value, and usage string.
+// The argument p points to a beaconcommon.Slot variable in which to store the value of the flag
+func SlotVarP(f *pflag.FlagSet, p *beaconcommon.Slot, name, shorthand string, value beaconcommon.Slot, usage string) {
+	v := &slotValue{p}
+	*v.slot = value
+	f.VarP(v, name, shorthand, usage)
+}

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/ethereum/go-ethereum v1.10.15
 	github.com/golang/mock v1.6.0
 	github.com/protolambda/zrnt v0.25.0
+	github.com/spf13/pflag v1.0.3
 	github.com/stretchr/testify v1.7.0
 	gopkg.in/h2non/gock.v1 v1.1.2
 )

--- a/go.sum
+++ b/go.sum
@@ -362,6 +362,7 @@ github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
+github.com/spf13/pflag v1.0.3 h1:zPAT6CGy6wXeQ7NtTnaTerfKOsV6V6F8agHXFiazDkg=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/status-im/keycard-go v0.0.0-20190316090335-8537d3370df4/go.mod h1:RZLeN1LMWmRsyYjvAu+I6Dm9QmlDaIIt+Y+4Kd7Tp+Q=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=


### PR DESCRIPTION
- Add a collection of Ethereum 1.0 & 2.0 flags compatible with [Cobra](https://github.com/spf13/cobra) library to build CLI applications