### PR TITLE
fix: make error channel in initService non-blocking

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -251,7 +251,7 @@ func (app *App) initServices(ctx context.Context) error {
 	app.logger.Infof("initialize services...")
 
 	wg := &sync.WaitGroup{}
-	errors := make(chan error)
+	errors := make(chan error, 3*len(app.services))
 
 	wg.Add(len(app.services))
 	for _, svc := range app.services {

--- a/app/app.go
+++ b/app/app.go
@@ -251,7 +251,7 @@ func (app *App) initServices(ctx context.Context) error {
 	app.logger.Infof("initialize services...")
 
 	wg := &sync.WaitGroup{}
-	errors := make(chan error, 3*len(app.services))
+	errors := make(chan error, len(app.services))
 
 	wg.Add(len(app.services))
 	for _, svc := range app.services {


### PR DESCRIPTION
Give the channel a conservative size that could fit all errors from the service initialization goroutines in order to make the channel non-blocking