### PR TITLE
feat(app): add option to configure custom connstate callback

### DIFF
--- a/net/http/server.go
+++ b/net/http/server.go
@@ -18,6 +18,18 @@ var (
 	statusStopped = "stopped"
 )
 
+type ConnStateCallbackTypeWrapper func(net.Conn, http.ConnState)
+
+func (c ConnStateCallbackTypeWrapper) MarshalJSON() ([]byte, error) {
+	// When the callback is overloaded.
+	if c == nil {
+		return []byte("onConnStateChangeOverloaded"), nil
+	}
+
+	// Otherwise..
+	return []byte("onConnStateChangeDefault"), nil
+}
+
 type ServerConfig struct {
 	Entrypoint *kilnnet.EntrypointConfig
 
@@ -30,7 +42,7 @@ type ServerConfig struct {
 
 	MaxHeaderBytes *int
 
-	ConnStateCallback func(net.Conn, http.ConnState)
+	ConnStateCallback ConnStateCallbackTypeWrapper
 }
 
 func (cfg *ServerConfig) SetDefault() *ServerConfig {

--- a/net/http/server.go
+++ b/net/http/server.go
@@ -3,6 +3,7 @@ package http
 import (
 	"context"
 	"fmt"
+	"net"
 	"net/http"
 	"sync"
 	"time"
@@ -28,6 +29,8 @@ type ServerConfig struct {
 	IdleTimeout *types.Duration
 
 	MaxHeaderBytes *int
+
+	ConnStateCallback func(net.Conn, http.ConnState)
 }
 
 func (cfg *ServerConfig) SetDefault() *ServerConfig {
@@ -90,6 +93,7 @@ func NewServer(cfg *ServerConfig) (*Server, error) {
 			ReadHeaderTimeout: cfg.ReadHeaderTimeout.Duration,
 			WriteTimeout:      cfg.WriteTimeout.Duration,
 			IdleTimeout:       cfg.IdleTimeout.Duration,
+			ConnState:         cfg.ConnStateCallback,
 		},
 		entrypoint: entrypoint,
 	}


### PR DESCRIPTION
Signed-off-by: Luca Georges Francois <luca.georges-francois@kiln.fi>

## Description

In order to register metrics such as the number of idle connection to an application, we must be able to set a custom callback that executes whenever the connState changes.